### PR TITLE
config: process env last to override defaults

### DIFF
--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -136,20 +136,6 @@ export function setConfigOnStart() {
 }
 
 function setOverrides() {
-  //console.log('process.env: ', process.env)
-  if (isDev() || isLinodeTestnet() || isLinodeMainnet()) {
-    console.log('================================================ >> ' + process.env.NODE_ENV)
-    // Not Trust Machines Kit - so override the btc connection params with platform values;
-    CONFIG.mongoDbUrl = process.env.mongoDbUrl || '';
-    CONFIG.mongoDbName = process.env.mongoDbName || '';
-    CONFIG.mongoUser = process.env.mongoUser || ''
-    CONFIG.mongoPwd = process.env.mongoPwd || '';
-    CONFIG.btcNode = process.env.btcNode || '';
-    CONFIG.btcRpcUser = process.env.btcRpcUser || '';
-    CONFIG.btcRpcPwd = process.env.btcRpcPwd || '';
-    CONFIG.btcSchnorrReveal = process.env.btcSchnorrReveal || '';
-    CONFIG.btcSchnorrReclaim = process.env.btcSchnorrReclaim || '';
-  }
   if (isSimnet() || isDev()) {
     // below are injected from the server environment but overridden  
     // with non secure values for local development. The mongo db 
@@ -176,6 +162,20 @@ function setOverrides() {
     console.log('linode env.. changing CONFIG.btcSchnorrReveal = ' + CONFIG.btcSchnorrReveal.substring(CONFIG.btcSchnorrReveal.length-3,CONFIG.btcSchnorrReveal.length))
     console.log('linode env.. changing CONFIG.btcSchnorrReclaim = ' + CONFIG.btcSchnorrReclaim.substring(0,2))
     console.log('linode env.. changing CONFIG.btcSchnorrReclaim = ' + CONFIG.btcSchnorrReclaim.substring(CONFIG.btcSchnorrReveal.length-3,CONFIG.btcSchnorrReveal.length))
+  }
+  //console.log('process.env: ', process.env)
+  if (isDev() || isLinodeTestnet() || isLinodeMainnet()) {
+    console.log('================================================ >> ' + process.env.NODE_ENV)
+    // Not Trust Machines Kit - so override the btc connection params with platform values;
+    CONFIG.mongoDbUrl = process.env.mongoDbUrl || '';
+    CONFIG.mongoDbName = process.env.mongoDbName || '';
+    CONFIG.mongoUser = process.env.mongoUser || ''
+    CONFIG.mongoPwd = process.env.mongoPwd || '';
+    CONFIG.btcNode = process.env.btcNode || '';
+    CONFIG.btcRpcUser = process.env.btcRpcUser || '';
+    CONFIG.btcRpcPwd = process.env.btcRpcPwd || '';
+    CONFIG.btcSchnorrReveal = process.env.btcSchnorrReveal || '';
+    CONFIG.btcSchnorrReclaim = process.env.btcSchnorrReclaim || '';
   }
 }
 


### PR DESCRIPTION
Use the following template to create your pull request
When trying to integrate the bridge-api into `devenv` for https://github.com/stacks-network/sbtc/issues/141 I ran across an issue when the environment variable I set in compose would be processed and then overwritten subsequently.

Here is an example log, which displays the issue.

```
> bridge-api@1.0.0 start
> node dist/src/app.js

================================================ >> undefined
linode env.. changing CONFIG.mongoDbName = sbtc-bridge-simnet-db
linode env.. changing CONFIG.mongoUser = dockerdev1
linode env.. changing CONFIG.mongoPwd = Fb
linode env.. process.env.mongoDbName = devnet
linode env.. process.env.BTC_NODE = bitcoin:18443
linode env.. changing CONFIG.btcNode = http://localhost:18443
linode env.. changing CONFIG.btcRpcUser = devnet
linode env.. changing CONFIG.btcSchnorrReveal = 93
linode env.. changing CONFIG.btcSchnorrReveal = 62d
linode env.. changing CONFIG.btcSchnorrReclaim = eb
linode env.. changing CONFIG.btcSchnorrReclaim = 98c
================================================ >> undefined
linode env.. changing CONFIG.mongoDbName = sbtc-bridge-simnet-db
linode env.. changing CONFIG.mongoUser = dockerdev1
linode env.. changing CONFIG.mongoPwd = Fb
linode env.. process.env.mongoDbName = devnet
linode env.. process.env.BTC_NODE = bitcoin:18443
linode env.. changing CONFIG.btcNode = http://localhost:18443
linode env.. changing CONFIG.btcRpcUser = devnet
linode env.. changing CONFIG.btcSchnorrReveal = 93
linode env.. changing CONFIG.btcSchnorrReveal = 62d
linode env.. changing CONFIG.btcSchnorrReclaim = eb
linode env.. changing CONFIG.btcSchnorrReclaim = 98c
Express is listening at http://localhost:3010
```


## Type of Change
- Bug fix

The main idea here, is to process the ENV variable last, incase there is an override needed. 



