### PR TITLE
mongo: uri: enforce SRV URIs for non development use cases

### DIFF
--- a/sbtc-bridge-api/src/lib/data/db_models.ts
+++ b/sbtc-bridge-api/src/lib/data/db_models.ts
@@ -9,8 +9,15 @@ let peginRequest:Collection;
 let commitments:Collection;
   
 export async function connect() {
-	const uri = `mongodb+srv://${getConfig().mongoUser}:${getConfig().mongoPwd}@${getConfig().mongoDbUrl}/?retryWrites=true&w=majority`;
-	//console.log("Mongo: " + uri);
+	const environ = process.env.NODE_ENV;
+	var uri_prefix:string = 'mongodb+srv'
+	if (environ === 'test' || environ === 'development' || environ === 'dev') {
+	  // SRV URIs have the additional security requirements on hostnames.
+	  // A FQDN is not required for development.
+	  uri_prefix = 'mongodb'
+	}
+	const uri = `${uri_prefix}://${getConfig().mongoUser}:${getConfig().mongoPwd}@${getConfig().mongoDbUrl}/?retryWrites=true&w=majority`;
+	// console.log("Mongo: " + uri);
 
 	// The MongoClient is the object that references the connection to our
 	// datastore (Atlas, for example)


### PR DESCRIPTION
## Description

If a SRV URI prefix is used it requires a FQDN for mongodb. When running in devenv, we don't have a FQDN for mongodb, so we need to relax this requirement, as it throws the following error:

`throw new error_1.MongoAPIError('URI must include hostname, domain name, and tld');`

This is not needed for development use cases, so lets remove the SRV prefix if NODE_ENV is set to development.
