### PR TITLE
lib/config: allow overrides for devnet

### DIFF
--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -176,6 +176,11 @@ function setOverrides() {
     CONFIG.btcRpcPwd = process.env.btcRpcPwd || '';
     CONFIG.btcSchnorrReveal = process.env.btcSchnorrReveal || '';
     CONFIG.btcSchnorrReclaim = process.env.btcSchnorrReclaim || '';
+    CONFIG.sbtcContractId = process.env.sbtcContractId || '';
+    CONFIG.network = process.env.network || '';
+    CONFIG.stacksApi = process.env.stacksApi || '';
+    CONFIG.stacksExplorerUrl =  process.env.stacksExplorerUrl || '';
+    CONFIG.bitcoinExplorerUrl = process.env.bitcoinExplorerUrl|| '';
   }
 }
 


### PR DESCRIPTION
## Description

For devenv, its handy to be able to override the following config with environment variable:

- network
- bitcoinExplorerUrl
- stacksApi
- stacksExplorerUrl
- sbtcContractId