### PR TITLE
Removed reclaim and reveal keys - see https://github.com/stacks-netwo…

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 
 VITE_PUBLIC_APP_NAME=sBTC Bridge API
 VITE_PUBLIC_APP_VERSION=1.0.0
-VITE_ORIGIN=http://bridge.stx.eco/bridge-api/testnet/v1
+VITE_ORIGIN=http://bridge.sbtc.tech/bridge-api/testnet/v1
 VITE_NETWORK=testnet
 VITE_SBTC_WALLET=tb1q6ue638m4t5knwxl4kwhwyuffttlp0ffee3zn3e
-VITE_BRIDGE_API=https://bridge.stx.eco/bridge-api/testnet/v1
-VITE_SIGNER_API=https://bridge.stx.eco/signer-api/testnet/v1
+VITE_BRIDGE_API=https://bridge.sbtc.tech/bridge-api/testnet/v1
+VITE_SIGNER_API=https://bridge.sbtc.tech/signer-api/testnet/v1
 VITE_STACKS_API=https://api.testnet.hiro.so
 VITE_STACKS_EXPLORER=https://explorer.hiro.so
 VITE_MEMPOOL_EXPLORER=https://mempool.space/testnet/api

--- a/.env.local
+++ b/.env.local
@@ -1,10 +1,10 @@
 
 VITE_PUBLIC_APP_NAME=sBTC Bridge API
 VITE_PUBLIC_APP_VERSION=1.0.0
-VITE_ORIGIN=http://bridge.stx.eco/bridge-api/testnet/v1
+VITE_ORIGIN=http://bridge.sbtc.tech/bridge-api/testnet/v1
 VITE_NETWORK=testnet
-VITE_BRIDGE_API=https://bridge.stx.eco/bridge-api/testnet/v1
-VITE_SIGNER_API=https://bridge.stx.eco/signer-api/testnet/v1
+VITE_BRIDGE_API=https://bridge.sbtc.tech/bridge-api/testnet/v1
+VITE_SIGNER_API=https://bridge.sbtc.tech/signer-api/testnet/v1
 VITE_STACKS_API=https://api.testnet.hiro.so
 VITE_STACKS_EXPLORER=https://explorer.hiro.so
 VITE_MEMPOOL_EXPLORER=https://mempool.space/testnet/api

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Indexes and caches contract data to make the api client application faster
 and more flexible.
 
-API [documentation](https://bridge.stx.eco/bridge-api/docs/).
+API [documentation](https://bridge.sbtc.tech/bridge-api/docs/).
 
 ## Development
 
@@ -49,7 +49,7 @@ docker run -d -t -i --network host --name bridge_api_staging -p 3010:3010 -e NOD
 
 ## Swagger API Docs
 
-See https://bridge.stx.eco/bridge-api/docs/#/
+See https://bridge.sbtc.tech/bridge-api/docs/#/
 
 ## Deployment
 

--- a/sbtc-bridge-api/package-lock.json
+++ b/sbtc-bridge-api/package-lock.json
@@ -29,7 +29,7 @@
         "morgan": "^1.10.0",
         "node-cron": "^3.0.2",
         "node-fetch": "^2.6.9",
-        "sbtc-bridge-lib": "^1.1.1",
+        "sbtc-bridge-lib": "^1.1.2",
         "swagger-ui-express": "^4.6.3",
         "tsoa": "^5.1.1",
         "uninstall": "^0.0.0",
@@ -6599,9 +6599,9 @@
       }
     },
     "node_modules/sbtc-bridge-lib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.1.1.tgz",
-      "integrity": "sha512-OPK2oM3U6+BzJY29YeXCFmucOrupa2Xk5C/0jV9TCANqJLicx8ZxvGHkMQAbDk5gJaqs6iKz3xJ7TxhcljmcNw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.1.2.tgz",
+      "integrity": "sha512-BMUt5xvle1JRZxia0DWL2yyFBsl5ke7f9GHWsMzNpIHIQhjW6qqTf5s3ZWTutp2PF86F8Dh9QTpmLMbeA94Y/g==",
       "dependencies": {
         "@noble/secp256k1": "^2.0.0",
         "@scure/base": "^1.1.1",

--- a/sbtc-bridge-api/package.json
+++ b/sbtc-bridge-api/package.json
@@ -74,7 +74,7 @@
     "morgan": "^1.10.0",
     "node-cron": "^3.0.2",
     "node-fetch": "^2.6.9",
-    "sbtc-bridge-lib": "^1.1.1",
+    "sbtc-bridge-lib": "^1.1.2",
     "swagger-ui-express": "^4.6.3",
     "tsoa": "^5.1.1",
     "uninstall": "^0.0.0",

--- a/sbtc-bridge-api/src/app.ts
+++ b/sbtc-bridge-api/src/app.ts
@@ -71,10 +71,6 @@ if (isDev() || isLocalRegtest() || isLocalTestnet()) {
   console.log('linode env.. changing CONFIG.mongoPwd = ' + getConfig().mongoPwd.substring(0,2))
   console.log('linode env.. changing CONFIG.btcNode = ' + getConfig().btcNode)
   console.log('linode env.. changing CONFIG.btcRpcUser = ' + getConfig().btcRpcUser)
-  console.log('linode env.. changing CONFIG.btcSchnorrReveal = ' + getConfig().btcSchnorrReveal.substring(0,2))
-  console.log('linode env.. changing CONFIG.btcSchnorrReveal = ' + getConfig().btcSchnorrReveal.substring(getConfig().btcSchnorrReveal.length-3, getConfig().btcSchnorrReveal.length))
-  console.log('linode env.. changing CONFIG.btcSchnorrReclaim = ' + getConfig().btcSchnorrReclaim.substring(0,2))
-  console.log('linode env.. changing CONFIG.btcSchnorrReclaim = ' + getConfig().btcSchnorrReclaim.substring(getConfig().btcSchnorrReveal.length-3, getConfig().btcSchnorrReveal.length))
 }
 
 async function connectToMongoCloud() {

--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -11,8 +11,6 @@ const SIMNNET_CONFIG = {
   btcNode: 'http://localhost:18443',
   btcRpcUser: 'devnet',
   btcRpcPwd: 'devnet',
-  btcSchnorrReveal: '',
-  btcSchnorrReclaim: '',
   host: 'http://localhost', 
   port: PORT,
   network: 'simnet',
@@ -36,8 +34,6 @@ const DEVNET_CONFIG = {
   btcNode: 'bitcoind.testnet.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem', 
-  btcSchnorrReveal: '',
-  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: 3010,
   walletPath: '/wallet/descwallet',
@@ -61,8 +57,6 @@ const LINODE_TESTNET_CONFIG = {
   btcNode: 'bitcoind.testnet.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem',
-  btcSchnorrReveal: '',
-  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: 3010,
   walletPath: '/wallet/SBTC-0003',
@@ -86,8 +80,6 @@ const LINODE_MAINNET_CONFIG = {
   btcNode: '',
   btcRpcUser: '',
   btcRpcPwd: '',
-  btcSchnorrReveal: '',
-  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: 3020,
   network: 'mainnet',
@@ -110,8 +102,6 @@ let CONFIG: {
   btcNode: string; 
   btcRpcUser: string; 
   btcRpcPwd: string; 
-  btcSchnorrReveal: string; 
-  btcSchnorrReclaim: string; 
   host: string; 
   port: number; 
   walletPath: string; 
@@ -148,8 +138,6 @@ function setOverrides() {
     CONFIG.btcRpcUser = 'devnet'
     CONFIG.btcRpcPwd = 'devnet'
     // private keys for testing ability to sign PSBTs..
-    CONFIG.btcSchnorrReveal = '93a7e5ecde5eccc4fd858dfcf7d92011eade103600de0e8122d6fc5ffedf962d'
-    CONFIG.btcSchnorrReclaim = 'eb80b7f63eb74a215b6947b479e154a83cf429691dceab272c405b1614efb98c'    
   } else if (isDev() || isLinodeTestnet() || isLinodeMainnet()) {
     // localhost params provided by docker environment
     CONFIG.mongoDbUrl = process.env.mongoDbUrl || '';
@@ -159,8 +147,6 @@ function setOverrides() {
     CONFIG.btcNode = process.env.btcNode || '';
     CONFIG.btcRpcUser = process.env.btcRpcUser || '';
     CONFIG.btcRpcPwd = process.env.btcRpcPwd || '';
-    CONFIG.btcSchnorrReveal = process.env.btcSchnorrReveal || '';
-    CONFIG.btcSchnorrReclaim = process.env.btcSchnorrReclaim || '';
     CONFIG.sbtcContractId = process.env.sbtcContractId || '';
     CONFIG.network = process.env.network || '';
     CONFIG.stacksApi = process.env.stacksApi || '';

--- a/sbtc-bridge-lib/package.json
+++ b/sbtc-bridge-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtc-bridge-lib",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Library for sBTC Bridge web client and API apps ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sbtc-bridge-lib/src/deposit_utils.ts
+++ b/sbtc-bridge-lib/src/deposit_utils.ts
@@ -22,9 +22,9 @@ export const dust = 500;
  * @param stacksAddress the stacks address to materialise sBTC
  * @returns Transaction from @scure/btc-signer
  */
-export function buildDepositTransaction(network:string, uiPayload:DepositPayloadUIType, btcFeeRates:any, utxos:Array<UTXO>):Transaction {
+export function buildDepositTransaction(network:string, sbtcWalletPublicKey:string, uiPayload:DepositPayloadUIType, btcFeeRates:any, utxos:Array<UTXO>):Transaction {
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
-	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, uiPayload.sbtcWalletPublicKey)
+	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, sbtcWalletPublicKey)
 	const data = buildDepositPayload(network, uiPayload.principal);
 
 	const txFees = calculateDepositFees(network, false, uiPayload.amountSats, btcFeeRates.feeInfo, utxos, sbtcWalletAddress!, hex.decode(data))
@@ -71,12 +71,12 @@ export function getBridgeDeposit(network:string, uiPayload:DepositPayloadUIType,
 	return req;
 }
 
-export function getBridgeDepositOpDrop(network:string, uiPayload:DepositPayloadUIType, originator:string):BridgeTransactionType {
+export function getBridgeDepositOpDrop(network:string, sbtcWalletPublicKey:string, uiPayload:DepositPayloadUIType, originator:string):BridgeTransactionType {
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
 	
 	const data = buildData(network, uiPayload.principal, uiPayload.amountSats);
 	const scripts =  [
-		{ script: btc.Script.encode([hex.decode(data), 'DROP', hex.decode(uiPayload.sbtcWalletPublicKey), 'CHECKSIG']) },
+		{ script: btc.Script.encode([hex.decode(data), 'DROP', hex.decode(sbtcWalletPublicKey), 'CHECKSIG']) },
 		{ script: btc.Script.encode(['IF', 144, 'CHECKSEQUENCEVERIFY', 'DROP', hex.decode(uiPayload.reclaimPublicKey), 'CHECKSIG', 'ENDIF']) },
 	]
 	const script = btc.p2tr(btc.TAPROOT_UNSPENDABLE_KEY, scripts, net, true);

--- a/sbtc-bridge-lib/src/withdraw_utils.ts
+++ b/sbtc-bridge-lib/src/withdraw_utils.ts
@@ -21,10 +21,10 @@ export const dust = 500
  * @param btcFeeRates 
  * @returns Transaction from @scure/btc-signer
  */
-export function buildWithdrawTransaction(network:string, uiPayload:WithdrawPayloadUIType, utxos:Array<UTXO>, btcFeeRates:any) {
+export function buildWithdrawTransaction(network:string, sbtcWalletPublicKey:string, uiPayload:WithdrawPayloadUIType, utxos:Array<UTXO>, btcFeeRates:any) {
 	if (!uiPayload.signature) throw new Error('Signature of output 2 scriptPubKey is required');
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
-	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, uiPayload.sbtcWalletPublicKey)
+	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, sbtcWalletPublicKey)
 	const data = buildData(network, uiPayload.amountSats, uiPayload.signature, false)
 	const txFees = calculateWithdrawFees(network, false, utxos, uiPayload.amountSats, btcFeeRates, sbtcWalletAddress!, uiPayload.bitcoinAddress, uiPayload.paymentPublicKey, hex.decode(data))
 	const tx = new btc.Transaction({ allowUnknowOutput: true, allowUnknownInputs:true, allowUnknownOutputs:true });
@@ -45,14 +45,14 @@ export function buildWithdrawTransaction(network:string, uiPayload:WithdrawPaylo
  * @param originator 
  * @returns 
  */
-export function buildWithdrawTransactionOpDrop (network:string, uiPayload:WithdrawPayloadUIType, utxos:Array<UTXO>, btcFeeRates:any, originator:string) {
+export function buildWithdrawTransactionOpDrop (network:string, sbtcWalletPublicKey:string, uiPayload:WithdrawPayloadUIType, utxos:Array<UTXO>, btcFeeRates:any, originator:string) {
 	if (!uiPayload.signature) throw new Error('Signature of output 2 scriptPubKey is required');
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
-	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, uiPayload.sbtcWalletPublicKey)
+	const sbtcWalletAddress = getPegWalletAddressFromPublicKey(network, sbtcWalletPublicKey)
 	const txFees = calculateWithdrawFees(network, true, utxos, uiPayload.amountSats, btcFeeRates, sbtcWalletAddress!, uiPayload.bitcoinAddress, uiPayload.paymentPublicKey, undefined)
 	const tx = new btc.Transaction({ allowUnknowOutput: true, allowUnknownInputs:true, allowUnknownOutputs:true });
 	addInputs(network, uiPayload.amountSats, revealPayment, tx, false, utxos, uiPayload.paymentPublicKey);
-	const csvScript = getBridgeWithdrawOpDrop(network, uiPayload, originator);
+	const csvScript = getBridgeWithdrawOpDrop(network, sbtcWalletPublicKey, uiPayload, originator);
 	//(network, data, sbtcWalletAddress, uiPayload.bitcoinAddress);
 	if (!csvScript ) throw new Error('script required!');
 	
@@ -129,11 +129,11 @@ export function getWithdrawScript (network:string, data:Uint8Array, sbtcWalletAd
 }
 */
 
-  export function getBridgeWithdrawOpDrop(network:string, uiPayload:WithdrawPayloadUIType, originator:string):BridgeTransactionType {
+  export function getBridgeWithdrawOpDrop(network:string, sbtcWalletPublicKey:string, uiPayload:WithdrawPayloadUIType, originator:string):BridgeTransactionType {
 	const data = buildData(network, uiPayload.amountSats, uiPayload.signature!, true);
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
 	
-	let pk1U = hex.decode(uiPayload.sbtcWalletPublicKey)
+	let pk1U = hex.decode(sbtcWalletPublicKey)
 	let pk2U = hex.decode(uiPayload.reclaimPublicKey)
 	if (pk1U.length === 33) pk1U = pk1U.subarray(1)
 	if (pk2U.length === 33) pk2U = pk2U.subarray(1)


### PR DESCRIPTION
### Description
Bug Fix: Simplified the way the sbtc-wallet-public-key is handled and passed around.
Removed the dependence on reveal and reclaim public keys - these were custodial versions of the sbtc wallet public key used to unblock development work in early stages of project.

### Fix
The wallet connect click handler was failing to fire due to an earlier exception related to the wallets public key now being defined. This only happened in a certain context and had an easy fix which involved refactoring the the way the key was passed from the front to back end service.