### PR TITLE
Simple internal cache strategy for stateless info

### DIFF
--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -38,7 +38,7 @@ const DEVNET_CONFIG = {
   port: 3010,
   walletPath: '/wallet/descwallet',
   network: 'testnet',
-  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick',
+  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.asset',
   stacksApi: 'https://api.testnet.hiro.so',
   stacksExplorerUrl: 'https://explorer.hiro.co',
   bitcoinExplorerUrl: 'https://mempool.space/testnet/api',
@@ -61,7 +61,7 @@ const LINODE_TESTNET_CONFIG = {
   port: 3010,
   walletPath: '/wallet/SBTC-0003',
   network: 'testnet',
-  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.romeo-bridge',
+  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.asset',
   stacksApi: 'https://api.testnet.hiro.so',
   stacksExplorerUrl: 'https://explorer.hiro.co',
   bitcoinExplorerUrl: 'https://mempool.space/testnet/api',
@@ -84,7 +84,7 @@ const LINODE_MAINNET_CONFIG = {
   port: 3020,
   network: 'mainnet',
   walletPath: '/wallet/SBTC-0003',
-  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick',
+  sbtcContractId: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.asset',
   stacksApi: 'https://api.hiro.so',
   stacksExplorerUrl: 'https://explorer.hiro.co',
   bitcoinExplorerUrl: 'https://mempool.space/api',
@@ -154,7 +154,7 @@ function setOverrides() {
     CONFIG.bitcoinExplorerUrl = process.env.bitcoinExplorerUrl|| '';
   }
   if (isLocalTestnet()) {
-    CONFIG.btcNode = 'http://localhost:18332' // ie not via docker network
+    CONFIG.btcNode = 'localhost:18332' // ie not via docker network
   }
 }
 

--- a/sbtc-bridge-api/src/routes/sbtcRoutes.ts
+++ b/sbtc-bridge-api/src/routes/sbtcRoutes.ts
@@ -145,29 +145,11 @@ router.get("/events/:page", async (req, res, next) => {
  * @returns 
  */
 router.get("/init-ui", async (req, res, next) => {
-  try {
-    const controller1 = new SbtcWalletController();
-    const sbtcContractData = await controller1.fetchSbtcContractData();
-    //checkAddressForNetwork(getConfig().network, sbtcContractData.sbtcWalletAddress)
-    const controller2 = new TransactionController();
-    const keys = await controller2.getKeys();
-    const controller3 = new WalletController();
-    const controller = new BlocksController();
-    const btcFeeRates = await controller.getFeeEstimate();
-
-    const response = {
-      keys,
-      sbtcContractData,
-      btcFeeRates
-    }
-    return res.send(response);
-  } catch (error) {
-    console.log('Error in routes: ', error)
-    next('An error occurred fetching sbtc data.')
-  }
+  const controller = new SbtcWalletController();
+  return res.send(await controller.initUi());
 });
 
-/**
+/** 
  * fetchs sbtc contract data
  * @returns 
  */

--- a/sbtc-bridge-api/src/routes/schedules/JobScheduler.ts
+++ b/sbtc-bridge-api/src/routes/schedules/JobScheduler.ts
@@ -3,6 +3,7 @@ import { saveAllSbtcEvents } from '../events/events_helper.js';
 import { scanBridgeTransactions, scanPeginRRTransactions } from '../../lib/bitcoin/rpc_commit.js';
 import { updateExchangeRates } from '../../lib/bitcoin/api_blockcypher.js';
 import { checkReveal } from '../../lib/bitcoin/rpc_reveal.js';
+import { SbtcWalletController } from '../stacks/StacksRPCController.js';
 
 export const sbtcEventJob = cron.schedule('*/17 * * * *', (fireDate) => {
   console.log('Running: sbtcEventJob at: ' + fireDate);
@@ -39,4 +40,10 @@ export const exchangeRates = cron.schedule('*/5 * * * *', (fireDate) => {
   } catch (err) {
     console.log('Error running: exchangeRates: ', err);
   }
+});
+
+export const initUiCacheJob = cron.schedule('*/3 * * * *', (fireDate) => {
+  console.log('Running: exchangeRates at: ' + fireDate);
+  const controller = new SbtcWalletController();
+  controller.initUiCache()
 });

--- a/sbtc-bridge-api/src/swagger.json
+++ b/sbtc-bridge-api/src/swagger.json
@@ -617,6 +617,23 @@
 				]
 			}
 		},
+		"/bridge-api/{network}/v1/sbtc/init-ui": {
+			"get": {
+				"operationId": "InitUi",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": []
+			}
+		},
 		"/bridge-api/{network}/v1/sbtc/address/{address}/balance": {
 			"get": {
 				"operationId": "FetchUserSbtcBalance",


### PR DESCRIPTION
## Description

PR creates a simple cache for a couple of stateless endpoints which provide the UI with initialisation data.

Example:
/ui-init - provides sbtc contract data, info about exchange rates and fee estimates return a cached object

Scheduled job `initUiCacheJob` runs every three minutes and refreshes the cached  object

